### PR TITLE
Fixed Expected Initial value Issue

### DIFF
--- a/server/src/services/historyService.ts
+++ b/server/src/services/historyService.ts
@@ -17,6 +17,7 @@ export async function getHistory(strategyId: string) {
 
   const dateSeq = getDateSequence(strategy.start_date, strategy.interval);
   let totalShares = 0;
+  let initialExpectValue = -1;
 
   const result = dateSeq.map(date => {
     const assetEntry = assets.find(a => a[0] === date);
@@ -25,11 +26,14 @@ export async function getHistory(strategyId: string) {
     const priceEntry = prices.find(p => p[0] === date);
     const price = priceEntry ? parseFloat(priceEntry[1]) : 0;
 
-    const actual_value = totalShares * price;
+    const actualValue = totalShares * price;
+    if (initialExpectValue == -1) {
+      initialExpectValue = actualValue;
+    }
     const intervalCount = dateSeq.indexOf(date);
-    const expected_value = intervalCount * strategy.increment;
+    const expectedValue = intervalCount * strategy.increment + initialExpectValue;
 
-    return { date, actual_value, expected_value };
+    return { date, actualValue, expectedValue };
   });
 
   return result;

--- a/ui/src/pages/StrategyDetail.tsx
+++ b/ui/src/pages/StrategyDetail.tsx
@@ -26,8 +26,8 @@ interface Strategy {
 
 interface HistoryPoint {
   date: string;
-  actual_value: number;
-  expected_value: number;
+  actualValue: number;
+  expectedValue: number;
 }
 
 export default function StrategyDetail() {
@@ -53,14 +53,14 @@ export default function StrategyDetail() {
     datasets: [
       {
         label: 'Actual Value',
-        data: data.map(d => d.actual_value),
+        data: data.map(d => d.actualValue),
         borderColor: 'rgb(59, 130, 246)',
         backgroundColor: 'rgba(59, 130, 246, 0.3)',
         tension: 0.3,
       },
       {
         label: 'Expected Value',
-        data: data.map(d => d.expected_value),
+        data: data.map(d => d.expectedValue),
         borderColor: 'rgb(34, 197, 94)',
         backgroundColor: 'rgba(34, 197, 94, 0.3)',
         tension: 0.3,


### PR DESCRIPTION
- In strategy performance history, the expect value always begins from 0
which might be unuseful sometimes especially when the user already
holding certain shares of securities. So we might want the expected
value to begin with the market value based on the user's initial
holding. If the user provides no shares at the begining, start with 0